### PR TITLE
Remove temporally Chase H.Q. from TG-16 VC database

### DIFF
--- a/FriishProduce/database.json
+++ b/FriishProduce/database.json
@@ -85,9 +85,6 @@
   "pce": [
     { "title": "Bomberman '93 (USA)", "id": "PAAE" },
     { "title": "Bomberman '93 (EUR)", "id": "PAAP" },
-    { "title": "Chase H.Q. (USA)", "id": "PC2E" },
-    { "title": "Chase H.Q. (EUR)", "id": "PC2P" },
-    { "title": "TAITO Chase H.Q. (JPN)", "id": "PC2J" },
     { "title": "Dungeon Explorer (USA)", "id": "PACE" },
     { "title": "Dungeon Explorer (EUR)", "id": "PACP" },
     { "title": "Dungeon Explorer (JPN)", "id": "PACJ" },


### PR DESCRIPTION
All regions of the base TG-16 HuCard WAD "Chase H.Q." uses LZ77 0x11 compression in its ROM, currently not supported by FriishProduce.
Let's remove them temporally, until FriishProduce has support for LZ77 0x11 compression.